### PR TITLE
Update swagger-initializer.js

### DIFF
--- a/dist/swagger-initializer.js
+++ b/dist/swagger-initializer.js
@@ -2,8 +2,12 @@ window.onload = function() {
   //<editor-fold desc="Changeable Configuration Block">
 
   // the following lines will be replaced by docker/configurator, when it runs in a docker-container
+  
+  const urlParams = new URLSearchParams(window.location.search);
+  const specUrl = urlParams.get('url') || "blink-hendelse-api.yaml";
+  
   window.ui = SwaggerUIBundle({
-    url: "blink-hendelse-api.yaml",
+    url: specUrl,
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [


### PR DESCRIPTION
Fix the url parameter

- URL was hard-coded to always render blink-hendelse-api.yaml